### PR TITLE
add AWSCore 0.1 lower bound to REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,6 @@
 julia 0.5
-AWSCore
+AWSCore 0.1
 AWSSQS
 AWSLambda
+SymDict
+Retry


### PR DESCRIPTION
since it's the first version where AWSConfig is defined

also add direct dependencies on SymDict, Retry which are imported but not
directly depended on (assumed to be present as transitive deps)